### PR TITLE
fix: remove ref from UseTabListProps to generate concise d.ts

### DIFF
--- a/.changeset/spotty-stingrays-double.md
+++ b/.changeset/spotty-stingrays-double.md
@@ -1,0 +1,5 @@
+---
+"@chakra-ui/tabs": major
+---
+
+fix: remove ref from UseTabListProps to generate concise d.ts

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -181,7 +181,6 @@ export const [TabsProvider, useTabsContext] = createContext<UseTabsReturn>({
 export interface UseTabListProps {
   children?: React.ReactNode
   onKeyDown?: React.KeyboardEventHandler
-  ref?: React.Ref<any>
 }
 
 /**


### PR DESCRIPTION
## 📝 Description
Remove `ref` from the interface `UseTabListProps` which causes a typing problem as detailed in the current behavior section.

## ⛳️ Current behavior (updates)
When used together with ref forwarding, generated type signature of a component receiving `TabListProps` consists of large union of prop keys including DOM attributes derived from `@types/react`.

For example, the code below
```jsx
import { TabListProps } from "@chakra-ui/react"

export const MyComponent = React.forwardRef<HTMLDivElement, TabListProps>(
  (props, ref) => <TabList {...props} ref={ref} />
)
```
generates a d.ts file which looks like:
```ts
export declare const MyComponent: React.ForwardRefExoticComponent<Pick<TabListProps, "p" | "slot" | "style" | "title" | "clipPath" | "filter" | "as" | "key" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "suppressHydrationWarning" | "accessKey" | "className" | "contentEditable" | "contextMenu" | "dir" | "draggable" | "hidden" | "id" | "lang" | "nonce" | "placeholder" | "spellCheck" | "tabIndex" | "translate" | "radioGroup" | "role" | "about" | "datatype" | "inlist" | "prefix" | "property" | "resource" | "typeof" | "vocab" | "autoCapitalize" | "autoCorrect" | "autoSave" | "color" | "itemProp" | "itemScope" | "itemType" | "itemID" | "itemRef" | "results" | "security" | ... | "_selection" | "_rtl" | "_ltr" | "_mediaDark" | "_mediaReduceMotion" | "_dark" | "_light" | "__css" | "sx" | "css"> & React.RefAttributes<HTMLDivElement>>;
```

This behavior makes it difficult to use Chakra UI as the foundation of a purpose build custom component library, because dependent projects are required to use exactly the same version of `@types/react` as the library uses.

## 🚀 New behavior
With `ref` removed from `UseTabListProps`, TypeScript can generate a concise d.ts.
```ts
export declare const MyComponent: React.ForwardRefExoticComponent<TabListProps & React.RefAttributes<HTMLDivElement>>;
```

## 💣 Is this a breaking change (Yes/No): Yes
This will not change any runtime behaviour, but can lead to compile errors in codebases which previously built without any problem. This is because the ref object passed to TabList will be required to be specifically `RefObject<HTMLDivElement>` with this change, where `RefObject<any>` was accepted.

## 📝 Additional Information
